### PR TITLE
Add content library and locations pages; update sidenav with new links

### DIFF
--- a/src/lib/components/layout/sidenav.svelte
+++ b/src/lib/components/layout/sidenav.svelte
@@ -5,6 +5,10 @@
         { name: 'Dashboard', active: activePage === 'dashboard', href: '/' },
         { name: 'Representatives', active: activePage === 'representatives', href: '/representatives' },
         { name: 'Profile', active: activePage === 'profile', href: '/profile' },
+        {name: 'Settings', active: activePage === 'settings', href: '/settings'},
+        {name: 'Locations', active: activePage === 'locations', href: '/locations'},
+        {name: 'Content Library', active: activePage === 'content-library', href: '/content-library'},
+        {name: 'Virtual Assistant', active: activePage === 'virtual-assistant', href: '/virtual-assistant'},
 
     ];
 </script>

--- a/src/routes/(app)/content-library/+page.svelte
+++ b/src/routes/(app)/content-library/+page.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+    import { Button } from "$lib/components/ui/button";
+    import { Card } from "$lib/components/ui/card";
+    import { Pencil, Video, Image as ImageIcon, FileText } from 'lucide-svelte';
+    import Sidenav from '$lib/components/layout/sidenav.svelte';
+
+    type ContentType = 'Video' | 'Image' | 'PDF';
+    type ContentItem = {
+        id: string;
+        title: string;
+        type: ContentType;
+    };
+
+    // Sample data structure
+    let hostContent: ContentItem[] = [
+        { id: 'id0001', title: 'Title1', type: 'Video' },
+        { id: 'id0002', title: 'Title3', type: 'Video' },
+        { id: 'id0004', title: 'Title4', type: 'Image' },
+        // ... add more items as needed
+    ];
+
+    let repContent: ContentItem[] = [
+        { id: 'id0009', title: 'Title1', type: 'Video' },
+        { id: 'id0009', title: 'Title1', type: 'Image' },
+        // ... add more items as needed
+    ];
+
+    function getContentIcon(type: ContentType) {
+        switch(type) {
+            case 'Video':
+                return Video;
+            case 'Image':
+                return ImageIcon;
+            case 'PDF':
+                return FileText;
+            default:
+                return FileText;
+        }
+    }
+
+    function getContentColor(type: ContentType) {
+        switch(type) {
+            case 'Video':
+                return 'bg-gray-200';
+            case 'Image':
+                return 'bg-red-400';
+            case 'PDF':
+                return 'bg-blue-200';
+            default:
+                return 'bg-gray-200';
+        }
+    }
+</script>
+
+<div class="flex h-screen bg-gray-100">
+    <Sidenav activePage="content-library" />
+    
+    <div class="flex-1 overflow-auto">
+        <div class="container mx-auto p-6 space-y-8">
+            <!-- Host Content Library -->
+            <section>
+                <h2 class="text-2xl font-bold mb-4">Host Content Library</h2>
+                <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-4">
+                    {#each hostContent as item}
+                        <Card class={`relative ${getContentColor(item.type)} p-4 aspect-square flex flex-col`}>
+                            <Button 
+                                variant="ghost" 
+                                size="icon"
+                                class="absolute top-2 right-2"
+                            >
+                                <Pencil class="h-4 w-4" />
+                                <span class="sr-only">Edit</span>
+                            </Button>
+
+                            <div class="flex-1 flex items-center justify-center">
+                                <svelte:component 
+                                    this={getContentIcon(item.type)} 
+                                    class="h-8 w-8"
+                                />
+                            </div>
+
+                            <div class="mt-2 text-center">
+                                <p class="text-sm font-medium truncate">{item.title}</p>
+                                <p class="text-xs text-gray-600">{item.id}</p>
+                            </div>
+                        </Card>
+                    {/each}
+                </div>
+            </section>
+
+            <!-- Representative Content Library -->
+            <section>
+                <h2 class="text-2xl font-bold mb-4">Rep Content Library</h2>
+                <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-4">
+                    {#each repContent as item}
+                        <Card class={`relative ${getContentColor(item.type)} p-4 aspect-square flex flex-col`}>
+                            <Button 
+                                variant="ghost" 
+                                size="icon"
+                                class="absolute top-2 right-2"
+                            >
+                                <Pencil class="h-4 w-4" />
+                                <span class="sr-only">Edit</span>
+                            </Button>
+
+                            <div class="flex-1 flex items-center justify-center">
+                                <svelte:component 
+                                    this={getContentIcon(item.type)} 
+                                    class="h-8 w-8"
+                                />
+                            </div>
+
+                            <div class="mt-2 text-center">
+                                <p class="text-sm font-medium truncate">{item.title}</p>
+                                <p class="text-xs text-gray-600">{item.id}</p>
+                            </div>
+                        </Card>
+                    {/each}
+                </div>
+            </section>
+        </div>
+    </div>
+</div>
+
+<style>
+    /* Add any custom styles here if needed */
+</style> 

--- a/src/routes/(app)/locations/+page.svelte
+++ b/src/routes/(app)/locations/+page.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+    import { Button } from "$lib/components/ui/button";
+    import { Input } from "$lib/components/ui/input";
+    import { Label } from "$lib/components/ui/label";
+    import { Card, CardContent, CardHeader, CardTitle } from "$lib/components/ui/card";
+    import { Plus, Save } from 'lucide-svelte';
+    import Sidenav from '$lib/components/layout/sidenav.svelte';
+
+    type Location = {
+        name: string;
+        address: string;
+        city: string;
+        phone: string;
+        hours: {
+            [key: string]: string;
+        };
+    };
+
+    let locations: Location[] = [];
+    let currentLocation: Location = {
+        name: '',
+        address: '',
+        city: '',
+        phone: '',
+        hours: {
+            Mon: '',
+            Tue: '',
+            Wed: '',
+            Thurs: '',
+            Fri: '',
+            Sat: '',
+            Sun: ''
+        }
+    };
+
+    function handleSave() {
+        locations = [...locations, { ...currentLocation }];
+        // Reset form
+        currentLocation = {
+            name: '',
+            address: '',
+            city: '',
+            phone: '',
+            hours: {
+                Mon: '',
+                Tue: '',
+                Wed: '',
+                Thurs: '',
+                Fri: '',
+                Sat: '',
+                Sun: ''
+            }
+        };
+    }
+
+    function addAnotherLocation() {
+        handleSave();
+    }
+</script>
+
+<div class="flex h-screen bg-gray-100">
+    <Sidenav activePage="locations" />
+    
+    <div class="flex-1 overflow-auto">
+        <div class="container mx-auto p-6 space-y-6">
+            <Card>
+                <CardHeader>
+                    <CardTitle>Add a Location</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <form class="space-y-6">
+                        <div class="grid gap-4">
+                            <div class="grid gap-2">
+                                <Label for="locationName">Name of Location</Label>
+                                <Input 
+                                    id="locationName"
+                                    bind:value={currentLocation.name}
+                                    placeholder="e.g. Timmins Branch"
+                                />
+                            </div>
+
+                            <div class="grid gap-2">
+                                <Label for="address">Address</Label>
+                                <Input 
+                                    id="address"
+                                    bind:value={currentLocation.address}
+                                    placeholder="123 Street Name"
+                                />
+                            </div>
+
+                            <div class="grid gap-2">
+                                <Label for="city">City</Label>
+                                <Input 
+                                    id="city"
+                                    bind:value={currentLocation.city}
+                                    placeholder="Timmins"
+                                />
+                            </div>
+
+                            <div class="grid gap-2">
+                                <Label for="phone">Phone #</Label>
+                                <Input 
+                                    id="phone"
+                                    bind:value={currentLocation.phone}
+                                    placeholder="705-123-1234"
+                                    type="tel"
+                                />
+                            </div>
+
+                            <div class="grid gap-4">
+                                <Label>Hours of Operation</Label>
+                                {#each Object.entries(currentLocation.hours) as [day, hours]}
+                                    <div class="grid grid-cols-[100px_1fr] gap-4 items-center">
+                                        <Label for={day}>{day}:</Label>
+                                        <Input 
+                                            id={day}
+                                            bind:value={currentLocation.hours[day]}
+                                            placeholder="9:00 am - 5:00 pm"
+                                        />
+                                    </div>
+                                {/each}
+                            </div>
+                        </div>
+
+                        <div class="flex justify-between items-center pt-4">
+                            <Button 
+                                type="button" 
+                                on:click={handleSave}
+                                variant="default"
+                            >
+                                <Save class="mr-2 h-4 w-4" />
+                                Save
+                            </Button>
+
+                            <Button 
+                                type="button"
+                                on:click={addAnotherLocation}
+                                variant="outline"
+                            >
+                                <Plus class="mr-2 h-4 w-4" />
+                                Add Another Location
+                            </Button>
+                        </div>
+                    </form>
+                </CardContent>
+            </Card>
+
+            {#if locations.length > 0}
+                <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                    {#each locations as location}
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>{location.name}</CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <div class="space-y-2">
+                                    <p>{location.address}</p>
+                                    <p>{location.city}</p>
+                                    <p>{location.phone}</p>
+                                    <div class="pt-2">
+                                        <h4 class="font-semibold mb-2">Hours:</h4>
+                                        {#each Object.entries(location.hours) as [day, hours]}
+                                            {#if hours}
+                                                <p class="grid grid-cols-[100px_1fr]">
+                                                    <span class="font-medium">{day}:</span>
+                                                    <span>{hours}</span>
+                                                </p>
+                                            {/if}
+                                        {/each}
+                                    </div>
+                                </div>
+                            </CardContent>
+                        </Card>
+                    {/each}
+                </div>
+            {/if}
+        </div>
+    </div>
+</div>
+
+<style>
+    /* Additional custom styles can be added here if needed */
+</style> 


### PR DESCRIPTION
This pull request introduces new pages for managing content libraries and locations, and updates the sidebar navigation to include links to these new pages. The most important changes include adding new items to the sidebar, implementing the content library page, and creating the locations management page.

### Sidebar Navigation Update:
* [`src/lib/components/layout/sidenav.svelte`](diffhunk://#diff-ca7b1e8fc6e0b49f2202bf49e998b15132dbc8a429519f4fe74d39d673f0daddR8-R11): Added new navigation items for 'Settings', 'Locations', 'Content Library', and 'Virtual Assistant'.

### Content Library Page:
* [`src/routes/(app)/content-library/+page.svelte`](diffhunk://#diff-fca064bcd5a9e3a648c68ec62fa7d15283b3931904432187ac3d396709bd9bfbR1-R127): Implemented the content library page with sample data for host and representative content, including functionality to display and edit content items.

### Locations Management Page:
* [`src/routes/(app)/locations/+page.svelte`](diffhunk://#diff-ca8d6ecaf41bcb0663a1469e7eedcf2d3fb130fc12e1a213b1588089ad9ae58aR1-R183): Created the locations management page with a form to add new locations and display the list of added locations.